### PR TITLE
Fix config format for v1.0.0 ProjectConfig

### DIFF
--- a/charts/kube-stager/CHANGELOG.md
+++ b/charts/kube-stager/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conditional annotation rendering to avoid empty YAML blocks
 - Configurable ServiceMonitor TLS verification
 - Added multi-replica validation for leader election requirement
+- Config file format to match kube-stager v1.0.0 ProjectConfig (removed apiVersion/kind, added job configs)
 
 ## [0.3.0] and earlier
 See git history for changes in previous releases.

--- a/charts/kube-stager/README.md
+++ b/charts/kube-stager/README.md
@@ -16,13 +16,18 @@ helm install kube-stager ./charts/kube-stager -n kube-stager-system --create-nam
 
 ## Upgrading from v0.3.0
 
-Version 1.0.0 introduces a breaking change:
+Version 1.0.0 introduces breaking changes:
 
 - **Leader election enabled by default** - This is safe for both single and multi-replica deployments
   - **Required permissions**: The operator needs access to ConfigMaps and Leases in the deployment namespace
   - **Impact on single replica**: No functional change, minimal performance overhead (~5-10MB memory)
   - **Impact on multi-replica**: Enables proper leader election, prevents split-brain scenarios
   - The leader election mechanism ensures only one replica actively reconciles resources
+
+- **Configuration format changed** - Replaced controller-runtime's v1alpha1 config with custom ProjectConfig
+  - Job configuration (initJobConfig, migrationJobConfig, backupJobConfig) is now explicitly included in the config
+  - These fields have sensible defaults and can be customized via values.yaml
+  - The config file no longer uses Kubernetes CR format (apiVersion/kind removed from file-based config)
 
 ### Upgrade Steps
 

--- a/charts/kube-stager/templates/configmap-config.yaml
+++ b/charts/kube-stager/templates/configmap-config.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   controller_manager_config.yaml: |-
-    apiVersion: controller-config.operator.kube-stager.io/v1
-    kind: ProjectConfig
 {{ toYaml .Values.config | indent 4 }}

--- a/charts/kube-stager/values.yaml
+++ b/charts/kube-stager/values.yaml
@@ -40,21 +40,20 @@ config:
   webhook:
     port: 9443
   leaderElection: true
+  initJobConfig:
+    deadlineSeconds: 600
+    ttlSeconds: 600
+    backoffLimit: 0
+  migrationJobConfig:
+    deadlineSeconds: 600
+    ttlSeconds: 600
+    backoffLimit: 3
+  backupJobConfig:
+    deadlineSeconds: 600
+    ttlSeconds: 600
+    backoffLimit: 3
 #  sentryDsn: https://sentry.io/foo/bar
-#  initJobConfig:
-#    deadlineSeconds: 600
-#    ttlSeconds: 600
-#    backoffLimit: 3
-#  migrationJobConfig:
-#    deadlineSeconds: 600
-#    ttlSeconds: 600
-#    backoffLimit: 3
-#  backupJobConfig:
-#    deadlineSeconds: 600
-#    ttlSeconds: 600
-#    backoffLimit: 3
 #  cacheNamespace: ""
-#  gracefulShutDown: ""
 monitoring:
   enabled: false
   serviceMonitor:


### PR DESCRIPTION
- Remove apiVersion/kind from config file (not needed for file-based config)
- Add job config defaults to values.yaml to match operator expectations
- Document config format breaking change in README and CHANGELOG